### PR TITLE
ci: MacOS notarization fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,9 +59,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Currently 1.3.12 is the latest, and is broken when it comes
+      # to building MacOS binaries that are possible to sign.
+      # See: https://github.com/oven-sh/bun/pull/29272
+      # Will be fixed in 1.3.13
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.11
 
       - run: bun install
 


### PR DESCRIPTION
- Downgrade bun, since 1.3.12 is broken for building signable binaries (https://github.com/oven-sh/bun/pull/29272)