### PR TITLE
fix(oauth): bind callback listener to 127.0.0.1 to prevent WSL2 login hang

### DIFF
--- a/src/services/oauth.test.ts
+++ b/src/services/oauth.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from "bun:test"
+import { OAUTH_LISTEN_HOST } from "./oauth"
+
+describe("oauth callback listener", () => {
+  test("binds OAuth callback server to IPv4 loopback", () => {
+    expect(OAUTH_LISTEN_HOST).toBe("127.0.0.1")
+  })
+})

--- a/src/services/oauth.ts
+++ b/src/services/oauth.ts
@@ -87,7 +87,7 @@ const captureAccessTokenFromHTTPServer = (server: PolarEnvironment) =>
 				}
 			});
 
-			httpServer?.listen(3333, () => {
+			httpServer?.listen(3333, "127.0.0.1", () => {
 				open(authorizationUrl);
 			});
 		});


### PR DESCRIPTION
## Summary
This PR fixes a WSL2 OAuth callback issue in `polar login`.

## What was happening
The browser login step completed, but the callback from the browser on the Windows host could not reliably reach the Polar process running inside WSL. As a result, the CLI could appear to hang after environment selection.

<img width="904" height="386" alt="J6BCnTB051" src="https://github.com/user-attachments/assets/c6f7f578-8fc0-4a08-b0df-322f6399582a" />

## Why
This was caused by a loopback mismatch in the WSL2 host/browser callback path (IPv4 vs IPv6 behavior on `localhost`), where callback delivery and listener binding were not aligned.