### PR TITLE
fix #20: Add reconnect event to schema

### DIFF
--- a/src/commands/listen.ts
+++ b/src/commands/listen.ts
@@ -3,7 +3,11 @@ import { Effect, Either, Redacted, Schema } from "effect";
 import { EventSource } from "eventsource";
 import { environmentPrompt } from "../prompts/environment";
 import { organizationLoginPrompt } from "../prompts/organizations";
-import { ListenAck, ListenWebhookEvent } from "../schemas/Events";
+import {
+  ListenAck,
+  ListenReconnect,
+  ListenWebhookEvent,
+} from "../schemas/Events";
 import type { Token } from "../schemas/Tokens";
 import * as OAuth from "../services/oauth";
 
@@ -58,6 +62,12 @@ export const listen = Command.make("listen", { url }, ({ url }) =>
             return;
           }
 
+          const reconnect = Schema.decodeUnknownEither(ListenReconnect)(json);
+
+          if (Either.isRight(reconnect)) {
+            return;
+          }
+
           const webhookEvent =
             Schema.decodeUnknownEither(ListenWebhookEvent)(json);
 
@@ -84,6 +94,10 @@ export const listen = Command.make("listen", { url }, ({ url }) =>
         };
 
         eventSource.onerror = (error) => {
+          if (error.code === undefined) {
+            return;
+          }
+
           eventSource.close();
           resume(
             Effect.fail(

--- a/src/schemas/Events.ts
+++ b/src/schemas/Events.ts
@@ -6,6 +6,10 @@ export const ListenAck = Schema.Struct({
   secret: Schema.String,
 });
 
+export const ListenReconnect = Schema.Struct({
+  type: Schema.Literal("reconnect"),
+});
+
 export const ListenWebhookEvent = Schema.Struct({
   id: Schema.String,
   key: Schema.String,
@@ -26,4 +30,4 @@ export const ListenWebhookEvent = Schema.Struct({
   }),
 });
 
-export const ListenEvent = Schema.Union(ListenAck, ListenWebhookEvent);
+export const ListenEvent = Schema.Union(ListenAck, ListenReconnect, ListenWebhookEvent);


### PR DESCRIPTION
[server/polar/eventstream/endpoints.py](https://github.com/polarsource/polar/blob/8398c7db5433316e3a095d38f5383b93bf0cf6a2/server/polar/eventstream/endpoints.py#L54) intentionally closes the SSE stream after 10 minutes, sending a reconnect message, but the CLI didn't handle that message in the schema and would error without attempting a reconnect instead after 10 minutes.

With this change it should gracefully handle the reconnect instead.